### PR TITLE
Define ADKG interface

### DIFF
--- a/adkg/adkg.go
+++ b/adkg/adkg.go
@@ -1,6 +1,7 @@
 package adkg
 
 type Phase int8
+type SendMode int8
 
 const (
 	sharing Phase = iota
@@ -9,10 +10,23 @@ const (
 	keyDerivation
 )
 
-type ADKG struct {
-	Phase
+const (
+	BROADCAST SendMode = iota
+	UNICAST
+)
+
+type Message struct {
+	Phase   Phase
+	content []byte
 }
 
-func NewADKG() *ADKG {
-	return &ADKG{Phase: sharing}
+type Packet struct {
+	SendMode    SendMode
+	Destination int
+	Message     *Message
+}
+
+type ADKG interface {
+	RunADKG() error
+	HandleMessage(Message) ([]Packet, error)
 }


### PR DESCRIPTION
## Structs

- `Message`: contains a content as a byte array and a "phase" representing the current phase of the ADKG instance.
- `Packet`: represents a message to send. Contains a `Message`, a destination and a "send mode". The send mode is either broadcast, in which case the destination value is undefined and thus should not be used, or unicast and the destination field indicates to whom the message should be sent.

## Interface

- `RunADKG() error`
-> Initialize the protocol (e.g. draw random polynomials) and start an ACSS instance
- `HandleMessage(Message m) ([]Packet, bool)`
-> Handles a message received in the network for the protocol. This methods handles internally the message and then returns a list of packets to send (or nil if there is nothing to do) and a boolean indicating whether the protocol is finished.
- `Finished() (bool, []byte)`
-> Returns whether the protocol finished or not. If yes, the value that it terminated with is returned as second value. If false, the second value is undefined and should not be used.